### PR TITLE
Add threaded unescaping InputParser and tests

### DIFF
--- a/test/src/test_csv_input_parser.cpp
+++ b/test/src/test_csv_input_parser.cpp
@@ -59,6 +59,13 @@ TEST(CSVInputParserTest, SplitEscSVToVector) {
       expected, csvio::util::CSVInputParser<std::vector>::delim_split_unescaped(to_split, ','));
 }
 
+TEST(CSVInputParserTest, SplitEscSVToVectorThreaded) {
+  std::string_view to_split{"\"a\",\"b\",\"c\""};
+  std::vector<std::string> expected{"a", "b", "c"};
+  EXPECT_EQ(
+      expected, csvio::util::CSVInputParser<std::vector>::delim_split_unescaped_threaded(to_split, ','));
+}
+
 TEST(CSVInputParserTest, SplitEscSVToVectorNoUnescape) {
   std::string_view to_split{"\"a\",\"b\",\"c\""};
   std::vector<std::string> expected{"\"a\"", "\"b\"", "\"c\""};

--- a/test/src/test_csv_reader.cpp
+++ b/test/src/test_csv_reader.cpp
@@ -97,6 +97,17 @@ TEST(CSVReaderTest, ReadOneEscapedCSVLineWithEscapedQuotes) {
   EXPECT_EQ(false, csv_reader.good());
 }
 
+TEST(CSVReaderTest, ReadOneEscapedCSVLineWithEscapedQuotesThreaded) {
+  std::istringstream instream(
+      "\"\"\"a\"\"\",\"\"\"b\"\"\",\"\"\"c\"\"\",\"\"\"d\"\"\",\"\"\"e\"\"\"");
+  csvio::util::CSVLineReader csv_lr(instream);
+  csvio::CSVReader<std::vector> csv_reader(csv_lr, ',', false, true, csvio::util::CSVInputParser<std::vector>::delim_split_unescaped_threaded);
+
+  std::vector<std::string> expected{"\"a\"", "\"b\"", "\"c\"", "\"d\"", "\"e\""};
+  EXPECT_EQ(expected, csv_reader.read());
+  EXPECT_EQ(false, csv_reader.good());
+}
+
 TEST(CSVReaderTest, ReadOneCSVLineAltDelim) {
   std::istringstream instream("a|b|c|d|e");
   csvio::util::CSVLineReader csv_lr(instream);
@@ -188,6 +199,17 @@ TEST(CSVReaderTest, ReadOneEscapedCSVLineWithEscapedQuotesAltContainer) {
       "\"\"\"a\"\"\",\"\"\"b\"\"\",\"\"\"c\"\"\",\"\"\"d\"\"\",\"\"\"e\"\"\"");
   csvio::util::CSVLineReader csv_lr(instream);
   csvio::CSVReader<std::list> csv_reader(csv_lr);
+
+  std::list<std::string> expected{"\"a\"", "\"b\"", "\"c\"", "\"d\"", "\"e\""};
+  EXPECT_EQ(expected, csv_reader.read());
+  EXPECT_EQ(false, csv_reader.good());
+}
+
+TEST(CSVReaderTest, ReadOneEscapedCSVLineWithEscapedQuotesAltContainerThreaded) {
+  std::istringstream instream(
+      "\"\"\"a\"\"\",\"\"\"b\"\"\",\"\"\"c\"\"\",\"\"\"d\"\"\",\"\"\"e\"\"\"");
+  csvio::util::CSVLineReader csv_lr(instream);
+  csvio::CSVReader<std::list> csv_reader(csv_lr, ',', false, true, csvio::util::CSVInputParser<std::list>::delim_split_unescaped_threaded);
 
   std::list<std::string> expected{"\"a\"", "\"b\"", "\"c\"", "\"d\"", "\"e\""};
   EXPECT_EQ(expected, csv_reader.read());


### PR DESCRIPTION
Add a threaded InputParser that runs unescaping of RowContainer fields in separate threads.
Does not check hardware concurrency.
This may also benefit from a thread pool to avoid creating n * m threads.